### PR TITLE
ProductController now allows for cross-origin requests

### DIFF
--- a/src/main/java/de/htw/productmicroservice/port/user/ProductController.java
+++ b/src/main/java/de/htw/productmicroservice/port/user/ProductController.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping("/v1")
+@CrossOrigin(origins = "*")
 public class ProductController {
 
     private final IProductService productService;


### PR DESCRIPTION
As long as the services are running locally, we need to allow for cross origin requests in the controllers. This is true for all services.